### PR TITLE
fix for nil response running under Ruby 1.9.3

### DIFF
--- a/test/agcod/request_test.rb
+++ b/test/agcod/request_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class Agcod::RequestTest < Test::Unit::TestCase
+  context 'a health check request' do
+    setup do
+      Agcod::Configuration.load(File.join(File.dirname(__FILE__), "..", "app_root"), "test")
+      @request = Agcod::HealthCheck.new
+    end
+
+    should 'read response body' do
+      register_response @request.request_url, "health_check/success"
+      @request.submit
+      assert_equal "SUCCESS", @request.status
+    end
+  end
+end

--- a/test/fixtures/health_check/success.xml
+++ b/test/fixtures/health_check/success.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<HealthCheckResponse xmlns="http://agcws.amazon.com/doc/2008-01-01/">
+  <MessageHeader>
+    <messageType>HealthCheckResponse</messageType>
+    <sourceId>AMAZON</sourceId>
+    <recipientId>SomebodyImportant</recipientId>
+    <contentVersion>2008-01-01</contentVersion>
+    <retryCount>0</retryCount>
+  </MessageHeader>
+  <Status>
+    <statusCode>SUCCESS</statusCode>
+    <errorCode/>
+    <statusMessage>HealthCheck Request successful</statusMessage>
+  </Status>
+</HealthCheckResponse>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,8 +18,8 @@ FakeWeb.allow_net_connect = false
 require "macros/configuration"
 
 class Test::Unit::TestCase
-  def register_response(path, fixture)
-    
+  def register_response(uri, fixture)
+    FakeWeb.register_uri(:get, uri, :body => IO.read(xml_fixture_path(fixture)))
   end
 
   def xml_fixture_path(fixture)


### PR DESCRIPTION
In 1.9.3, the @response variable in request was always ending up nil.  Here's a fix for that issue, tested under 1.8.7 and 1.9.3.
