### PR TITLE
Removed HMAC Dependency

### DIFF
--- a/agcod.gemspec
+++ b/agcod.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "agcod"
 
-  s.add_dependency "ruby-hmac"
-
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'fakeweb'
   s.add_development_dependency 'mocha'

--- a/lib/agcod.rb
+++ b/lib/agcod.rb
@@ -7,8 +7,7 @@ require 'rexml/document'
 require "uri"
 require "cgi"
 require "base64"
-require "hmac-sha1"
-require "digest/sha1"
+require 'openssl'
 require "cgi"
 require "logger"
 

--- a/lib/agcod/request.rb
+++ b/lib/agcod/request.rb
@@ -35,7 +35,8 @@ module Agcod
       #remove all the = and & from the serialized string
       sanitized_string = string_to_sign.gsub(/=|&/, "")
       # puts sanitized_string
-      sha1 = HMAC::SHA1::digest(Agcod::Configuration.secret_key, sanitized_string)
+      digest = OpenSSL::Digest::Digest.new('sha1')
+      sha1 = OpenSSL::HMAC.digest(digest, Agcod::Configuration.secret_key, sanitized_string)
 
       #Base64 encoding adds a linefeed to the end of the string so chop the last character!
       CGI.escape(Base64.encode64(sha1).chomp)


### PR DESCRIPTION
The HMAC gem has been deprecated in favor of OpenSSL.  This
gem was still using HMAC.  All tests pass, Cucumber features
do not pass because of a lack of an Amazon connection.
