### PR TITLE
bugfix: clear response on submit so that retries will work correctly

### DIFF
--- a/lib/agcod/request.rb
+++ b/lib/agcod/request.rb
@@ -95,6 +95,7 @@ module Agcod
       http.open_timeout = 20
       http.use_ssl = true
 
+      @response = @xml_response = nil
       net_response, @response = http.get(uri.path + "?" + uri.query)
       @response ||= net_response.read_body
 

--- a/test/agcod/request_test.rb
+++ b/test/agcod/request_test.rb
@@ -13,4 +13,18 @@ class Agcod::RequestTest < Test::Unit::TestCase
       assert_equal "SUCCESS", @request.status
     end
   end
+
+  context 'retrying a create gift card request' do
+    setup do
+      Agcod::Configuration.load(File.join(File.dirname(__FILE__), "..", "app_root"), "test")
+      @request = Agcod::CreateGiftCard.new('value' => 100, 'request_id' => 12345)
+    end
+
+    should 'use response of retried request' do
+      uri = URI.parse(@request.request_url)
+      register_response %r{^#{ uri.scheme }://#{ uri.host }}, %w( create_gift_card/retry create_gift_card/success )
+      @request.submit
+      assert_equal "SUCCESS", @request.status
+    end
+  end
 end

--- a/test/fixtures/create_gift_card/retry.xml
+++ b/test/fixtures/create_gift_card/retry.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<CreateGiftCardResponse xmlns="http://agcws.amazon.com/doc/2008-01-01/">
+  <MessageHeader>
+    <messageType>CreateGiftCardResponse</messageType>
+    <sourceId>AMAZON</sourceId>
+    <recipientId>SomebodyImportant</recipientId>
+    <contentVersion>2008-01-01</contentVersion>
+    <retryCount>0</retryCount>
+  </MessageHeader>
+  <Status>
+    <statusCode>FAILURE</statusCode>
+    <errorCode>E100</errorCode>
+    <statusMessage>Please retry</statusMessage>
+  </Status>
+  <gcCreationRequestId>SomebodyImportant12345</gcCreationRequestId>
+  <gcCreationResponseId>ABC123DEF456</gcCreationResponseId>
+</CreateGiftCardResponse>

--- a/test/fixtures/create_gift_card/success.xml
+++ b/test/fixtures/create_gift_card/success.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<CreateGiftCardResponse xmlns="http://agcws.amazon.com/doc/2008-01-01/">
+  <MessageHeader>
+    <messageType>CreateGiftCardResponse</messageType>
+    <sourceId>AMAZON</sourceId>
+    <recipientId>SomebodyImportant</recipientId>
+    <contentVersion>2008-01-01</contentVersion>
+    <retryCount>1</retryCount>
+  </MessageHeader>
+  <Status>
+    <statusCode>SUCCESS</statusCode>
+    <errorCode></errorCode>
+    <statusMessage>CreateGiftCard Request successful</statusMessage>
+  </Status>
+  <gcCreationRequestId>SomebodyImportant12345</gcCreationRequestId>
+  <gcCreationResponseId>ABC123DEF456</gcCreationResponseId>
+  <gcClaimCode>AB12-CDE345-FG67</gcClaimCode>
+  <gcValue>
+    <amount>100</amount>
+    <currencyCode>USD</currencyCode>
+  </gcValue>
+</CreateGiftCardResponse>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,17 @@ require 'shoulda'
 require 'fakeweb'
 require 'mocha'
 
+module ActiveResource
+  class TimeoutError < StandardError
+  end
+end
+
+class String
+  def blank?
+    empty?
+  end
+end
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'agcod'
@@ -18,8 +29,12 @@ FakeWeb.allow_net_connect = false
 require "macros/configuration"
 
 class Test::Unit::TestCase
-  def register_response(uri, fixture)
-    FakeWeb.register_uri(:get, uri, :body => IO.read(xml_fixture_path(fixture)))
+  def register_response(uri, fixtures)
+    fixtures = [fixtures].flatten.map do |f|
+      { :body => IO.read(xml_fixture_path(f)) }
+    end
+
+    FakeWeb.register_uri(:get, uri, fixtures)
   end
 
   def xml_fixture_path(fixture)


### PR DESCRIPTION
When an initial request comes back as an error code E100 "RESEND" error, the memoized @xml_response should be cleared when re-submitting to make room for the subsequent response.
