### PR TITLE
[RFR] - Fix Signature V2 Implementation

### DIFF
--- a/lib/agcod/request.rb
+++ b/lib/agcod/request.rb
@@ -158,7 +158,7 @@ module Agcod
     def build_v2_string_to_sign(parameters)
       parsed_uri = URI.parse(Agcod::Configuration.uri)
 
-      string_to_sign = "GET\n#{parsed_uri.host.downcase}\n#{parsed_uri.path}\n"
+      string_to_sign = "GET\n#{parsed_uri.host.downcase}\n#{parsed_uri.request_uri}\n"
 
       parameters.sort.each_with_index do |v, i|
         string_to_sign << '&' unless i == 0
@@ -171,7 +171,7 @@ module Agcod
     end
 
     def urlencode(plaintext)
-      URI.encode(plaintext.to_s)
+      CGI.escape(plaintext.to_s).gsub("+", "%20").gsub("%7E", "~")
     end
   end
 end


### PR DESCRIPTION
This article proved to be pretty useful to get me started on the path of figuring this one out:

http://www.jamesmurty.com/2008/12/31/aws-query-signature-version-2/

It turned out that AWS didn't like the use of URI.encode.  I did a little reading and it seems that URI.encode doesn't conform to certain standards, so I'm not surprised AWS didn't like what we were sending them.  See a discussion here:

http://stackoverflow.com/questions/2824126/whats-the-difference-between-uri-escape-and-cgi-escape

Also, I think we want to pass in request_uri and not path when building the start of the string we're going to sign.

I started to use ERB::Util.url_encode but running the tests showed the need for another dependency to pass, so it seemed easier to just use CGI.escape which does what we wanted URI.encode to do, but actually works. 
